### PR TITLE
Automagic inputs

### DIFF
--- a/bemto.jade
+++ b/bemto.jade
@@ -26,6 +26,8 @@ mixin bemto_tag(tag)
     - newTag = 'a';
   if attributes.for
     - newTag = 'label';
+  if attributes.type
+    - newTag = 'input';
   else if attributes.src
     - newTag = 'img';
 


### PR DESCRIPTION
Hey! That’s me again.

It looks like using `type` attribute is a sign of intention to add some `<input>` to the page.

BTW the `else` part of `else if attributes.src` has some sense now, because `<input>` may have an `src` too.