### PR TITLE
Add <svg> to supported tags

### DIFF
--- a/bemto.jade
+++ b/bemto.jade
@@ -97,6 +97,7 @@ mixin bemto_tag(tag)
     when 'strong': strong&attributes(attributes): block
     when 'sub': sub&attributes(attributes): block
     when 'sup': sup&attributes(attributes): block
+    when 'svg': svg&attributes(attributes): block
     when 'table': table&attributes(attributes): block
     when 'tbody': tbody&attributes(attributes): block
     when 'td': td&attributes(attributes): block


### PR DESCRIPTION
Hi!

I’m in love with SVG sprites and every time I try to add block-specific styles for my icon there’s a `<div>` instead of `<svg>` in my markup.

This PR makes lines like `+e('svg').icon: use('xlink:href' = '#twitter')` to work as we expect them to.