### PR TITLE
Remove an attribute from tag if its value is false

### DIFF
--- a/lib/bemto_custom_tag.jade
+++ b/lib/bemto_custom_tag.jade
@@ -11,7 +11,7 @@ mixin bemto_custom_inline_tag(customTag, self_closing)
   = customTag
   if attributes
     - for (var attribute in attributes)
-      if attributes.hasOwnProperty(attribute) && attributes[attribute] !== undefined
+      if attributes.hasOwnProperty(attribute) && attributes[attribute] !== false && attributes[attribute] !== undefined
         = ' '
         = attribute
         != '="'


### PR DESCRIPTION
I recently upgraded to bemto 1.0, and realized that if I passed literal `false` to an attribute, bemto would convert it into the string `"false"` and the attribute would be present, which isn't the default Jade behaviour. See here: https://github.com/pugjs/jade/issues/240#issuecomment-17875875

Tested this fix and it seemed to restore the default expected behaviour.