### PR TITLE
Add a possibility to set global classes without prefix.

### DIFF
--- a/lib/bemto.jade
+++ b/lib/bemto.jade
@@ -119,6 +119,10 @@ mixin b(options)
       each bemto_object in bemto_objects
         if bemto_object.name
           - var prefix = settings.prefix
+          - var global_classes_prefix_reg_exp = new RegExp('^(' + settings.global_classes_prefix + ')')
+          if settings.global_classes_prefix && bemto_object.name.match(global_classes_prefix_reg_exp)
+            - prefix = ''
+            - bemto_object.name = bemto_object.name.replace(global_classes_prefix_reg_exp, '')
           if bemto_object.context
             - prefix += bemto_object.context + settings.output_element
           - new_classes.push(prefix + bemto_object.name)

--- a/lib/settings.jade
+++ b/lib/settings.jade
@@ -11,7 +11,8 @@ include tag_metadata
     'modifier': '_',
     'default_tag': 'div',
     'nosrc_substitute': true,
-    'flat_elements': true
+    'flat_elements': true,
+    'global_classes_prefix': false
   }
 
   var bemto_output_settings = ['element', 'modifier'];

--- a/test/cases/10_global_classes.html
+++ b/test/cases/10_global_classes.html
@@ -1,0 +1,8 @@
+<div class="b-block b-not-global b---global">
+  <div class="b-block__element">foo
+  </div>
+</div>
+<div class="b-block b-not-global global">
+  <div class="b-block__element">foo
+  </div>
+</div>

--- a/test/cases/10_global_classes.jade
+++ b/test/cases/10_global_classes.jade
@@ -1,0 +1,16 @@
+include ../../bemto
+
+-
+  set_bemto_settings({
+    prefix: 'b-'
+  })
++b.block.not-global.--global
+  +e.element foo
+
+-
+  set_bemto_settings({
+    prefix: 'b-',
+    global_classes_prefix: '--'
+  })
++b.block.not-global.--global
+  +e.element foo


### PR DESCRIPTION
I added new parameter **global_classes_prefix** to settings. If this parameter contain some string then all classes that have that string at the beginning will be added without prefix and this string.
