### PR TITLE
Attribute escaping in `bemto_custom_inline_tag` mixin fix.

### DIFF
--- a/lib/bemto.jade
+++ b/lib/bemto.jade
@@ -130,6 +130,10 @@ mixin b(options)
     else
       - attributes.class = undefined
 
+    if attributes.klass
+      - attributes.class = attributes.class ? [attributes.class, attributes.klass].join(' ') : attributes.klass
+      - delete attributes.klass
+
   if block
     +bemto_tag(tag, tagMetadata)&attributes(attributes)
       block

--- a/lib/bemto_custom_tag.jade
+++ b/lib/bemto_custom_tag.jade
@@ -13,9 +13,9 @@ mixin bemto_custom_inline_tag(customTag, self_closing)
     - for (var attribute in attributes)
       if attributes.hasOwnProperty(attribute) && attributes[attribute] !== false && attributes[attribute] !== undefined
         = ' '
-        = attribute
+        != attribute
         != '="'
-        = attributes[attribute] === true ? attribute : attributes[attribute]
+        != attributes[attribute] === true ? attribute : attributes[attribute]
         != '"'
   if self_closing
     != '/>'

--- a/test/cases/10_escape.html
+++ b/test/cases/10_escape.html
@@ -1,0 +1,2 @@
+<div data-unescaped="<html>" data-escaped="&lt;html&gt;" class="block">
+</div><img src="<html>" class="block" alt="" role="presentation"/><img src="&lt;html&gt;" class="block" alt="" role="presentation"/>

--- a/test/cases/10_escape.jade
+++ b/test/cases/10_escape.jade
@@ -1,0 +1,7 @@
+include ../../bemto
+
++b.block(data-unescaped!="<html>", data-escaped="<html>")
+
++b.block(src!="<html>")
+
++b.block(src="<html>")


### PR DESCRIPTION
There was an issue in attributes escaping in `bemto_custom_inline_tag` mixin.

For example:
```
// There will be an image tag here because of src attribute:
+b.block(src!="<?php echo $something; ?>")
```
Would become:
```
<img src="&lt;php echo $something; &gt;" class="block" alt="" role="presentation"/>
```
Which is not an expected behaviour.

So, I made those changes and everything seems to work fine.